### PR TITLE
Fix triangle waveform generator

### DIFF
--- a/src/audio.ml
+++ b/src/audio.ml
@@ -757,7 +757,7 @@ module Mono = struct
         let volume = self#volume in
 	let omega = freq /. sr in
 	for i = 0 to len - 1 do
-	  let t = fracf (float i *. omega +. phase) +. 0.25 in
+	  let t = fracf (float i *. omega +. phase +. 0.25) in
 	  buf.(ofs + i) <- volume *. (if t < 0.5 then 4. *. t -. 1. else 4. *. (1. -. t) -. 1.)
 	done;
 	phase <- mod_float (phase +. float len *. omega) 1.


### PR DESCRIPTION
Attached are images of a 440Hz triangle wave with 44100Hz sample rate generated before the patch:

![triangle_before](https://user-images.githubusercontent.com/112119/33609476-28265768-d9c0-11e7-84a7-b077f512c133.png)

And after the patch:

![triangle_after](https://user-images.githubusercontent.com/112119/33609478-2a935e42-d9c0-11e7-8de0-a877ba6b2349.png)
