### PR TITLE
Start using floatarray internally.

### DIFF
--- a/external/mm_mad.ml
+++ b/external/mm_mad.ml
@@ -60,7 +60,7 @@ class virtual reader =
     channels <- c;
     rb <- Audio.Ringbuffer_ext.create channels 0
 
-    method private decode = Mad.decode_frame_float self#mf
+    method private decode = Mad.decode_frame_floatarray self#mf
     method close = self#stream_close
 
     method read buf ofs len =

--- a/external/mm_pulseaudio.ml
+++ b/external/mm_pulseaudio.ml
@@ -45,6 +45,6 @@ class writer client_name stream_name channels rate =
       in
       Simple.create ~client_name ~dir:Dir_playback ~stream_name ~sample ()
 
-    method write = Simple.write dev
+    method write = Simple.write_floatarray dev
     method close = Simple.free dev
   end

--- a/src/audio.mli
+++ b/src/audio.mli
@@ -85,7 +85,7 @@ end
 (** Operations on mono buffers (with only one channel). *)
 module Mono : sig
   (** A mono buffer. *)
-  type t = float array
+  type t = floatarray
 
   type buffer = t
 
@@ -306,7 +306,7 @@ module Mono : sig
 end
 
 (** An audio buffer. *)
-type t = float array array
+type t = floatarray array
 
 type buffer = t
 


### PR DESCRIPTION
`floatarray` are defined in `Float.Array` since OCaml `4.08`. They are guaranteed to be always be unboxed flat arrays. If the compiler supports it (see: https://github.com/ocaml/ocaml/pull/12019), `floatarray` can be cast to `double *` arrays and passed to a C function.

Currently, they share the same underlying representation as `float array` so switching to the shouldn't impact performances. However, this could change (or can be by disabling flat float arrays in the compiler) so this will make the implementation more robust to future changes in the compiler.