### PR TITLE
Fix note names

### DIFF
--- a/src/audio.ml
+++ b/src/audio.ml
@@ -76,18 +76,18 @@ module Note = struct
   let to_string n =
     let n, o = modulo n in
     (match n with
-      | 0 -> "A"
-      | 1 -> "A#"
-      | 2 -> "B"
-      | 3 -> "C"
-      | 4 -> "C#"
-      | 5 -> "D"
-      | 6 -> "D#"
-      | 7 -> "E"
-      | 8 -> "F"
-      | 9 -> "F#"
-      | 10 -> "G"
-      | 11 -> "G#"
+      | 0 -> "C"
+      | 1 -> "C#"
+      | 2 -> "D"
+      | 3 -> "D#"
+      | 4 -> "E"
+      | 5 -> "F"
+      | 6 -> "F#"
+      | 7 -> "G"
+      | 8 -> "G#"
+      | 9 -> "A"
+      | 10 -> "A#"
+      | 11 -> "B"
       | _ -> assert false)
     ^ " " ^ string_of_int o
 


### PR DESCRIPTION
The function `Mm_audio.Audio.Note.to_string` gets the octave right but not the note name: it wrongly translates pitch no. 60 as `A 4`, whereas the correct name is `C 4`.