### PR TITLE
Store YUV420 in a single array.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+0.9.0 (unreleased)
+=====
+- BREAKING: Make all YUV420 image planes views over
+  a main data array. Can be used to pass a single
+  pointer to the image for APIs requiring it.
+  Renamed `data` into `planes`, added new `data`
+  returning the main data array.
+
 0.8.5 (2024-02-05)
 =====
 - Fix note names (#18).

--- a/src/image.mli
+++ b/src/image.mli
@@ -284,7 +284,7 @@ module YUV420 : sig
   val make :
     int -> int -> ?alpha:Data.t -> Data.t -> int -> Data.t -> Data.t -> int -> t
 
-  val make_data : int -> int -> Data.t -> int -> int -> t
+  val make_data : ?alpha:bool -> int -> int -> Data.t -> int -> int -> t
   val create : ?blank:bool -> ?y_stride:int -> ?uv_stride:int -> int -> int -> t
 
   (** Ensure that the image has an alpha channel. *)
@@ -313,7 +313,8 @@ module YUV420 : sig
   val u : t -> Data.t
   val v : t -> Data.t
   val uv_stride : t -> int
-  val data : t -> Data.t * Data.t * Data.t
+  val data : t -> Data.t
+  val planes : t -> Data.t * Data.t * Data.t
   val alpha : t -> Data.t option
   val set_alpha : t -> Data.t option -> unit
   val dimensions : t -> int * int

--- a/src/imageBase.ml
+++ b/src/imageBase.ml
@@ -54,6 +54,8 @@ module Data = struct
   let alloc n =
     Bigarray.Array1.create Bigarray.int8_unsigned Bigarray.C_layout n
 
+  external realloc : t -> int -> unit = "caml_data_realloc"
+
   (** [round n k] rounds [n] to the nearest upper multiple of [k]. *)
   let round k n = (n + (k - 1)) / k * k
 

--- a/src/imageYUV420.ml
+++ b/src/imageYUV420.ml
@@ -68,11 +68,12 @@ let data_len ~alpha ~y_stride ~uv_stride ~height () =
 let ensure_alpha img =
   if img.alpha = None then (
     let len = img.height * img.y_stride in
-    Data.realloc img.data (Data.length img.data + len);
     let offset =
       data_len ~alpha:false ~y_stride:img.y_stride ~uv_stride:img.uv_stride
         ~height:img.height ()
     in
+    let data_len = Data.length img.data in
+    if data_len < offset + len then Data.realloc img.data (data_len + len);
     let a = Data.sub img.data offset len in
     Data.fill a 0xff;
     img.alpha <- Some a)

--- a/src/image_data.c
+++ b/src/image_data.c
@@ -153,3 +153,16 @@ CAMLprim value caml_data_blit_off(value _src, value _soff, value _dst,
   memcpy(dst + doff, src + soff, len);
   CAMLreturn(Val_unit);
 }
+
+CAMLprim value caml_data_realloc(value _src, value _len) {
+  CAMLparam1(_src);
+  struct caml_ba_array *src = Caml_ba_array_val(_src);
+  src->data = realloc(src->data, Long_val(_len));
+  src->dim[0] = Long_val(_len);
+
+  if (!src->data)
+    caml_raise_out_of_memory();
+
+  CAMLreturn(Val_unit);
+}
+

--- a/src/video.ml
+++ b/src/video.ml
@@ -217,7 +217,7 @@ module AVI = struct
         let open Mm_image in
         let width = Image.YUV420.width img in
         let height = Image.YUV420.height img in
-        let y, u, v = Image.YUV420.data img in
+        let y, u, v = Image.YUV420.planes img in
         let y = Image.Data.to_string y in
         let u = Image.Data.to_string u in
         let v = Image.Data.to_string v in


### PR DESCRIPTION
This PR changes YUV420 memory reprepresentation to allocate all planes inside a single memory array.

This makes it possible to pass the whole frame to APIs expecting data in a single memory array without having to copy its data.

Thanks to the bigarray sub views, this should not change the rest of the library's logic.

The only breaking change is that the `data` function is renamed `planes` and a new `data` function is introduced which exports the whole frame's data.