### PR TITLE
Packed YUV frame

### DIFF
--- a/src/image.mli
+++ b/src/image.mli
@@ -283,10 +283,27 @@ module YUV420 : sig
       stride) U and V (with given stride). The strides of U and V are the same,
       the stride of the alpha channel is the same as Y. *)
   val make :
-    int -> int -> ?alpha:Data.t -> Data.t -> int -> Data.t -> Data.t -> int -> t
+    int ->
+    int ->
+    ?packed_data:Data.t ->
+    ?alpha:Data.t ->
+    Data.t ->
+    int ->
+    Data.t ->
+    Data.t ->
+    int ->
+    t
 
-  val make_data : int -> int -> Data.t -> int -> int -> t
-  val create : ?blank:bool -> ?y_stride:int -> ?uv_stride:int -> int -> int -> t
+  val make_data : ?alpha:bool -> int -> int -> Data.t -> int -> int -> t
+
+  val create :
+    ?blank:bool ->
+    ?alpha:bool ->
+    ?y_stride:int ->
+    ?uv_stride:int ->
+    int ->
+    int ->
+    t
 
   (** Ensure that the image has an alpha channel. *)
   val ensure_alpha : t -> unit

--- a/src/imageGeneric.ml
+++ b/src/imageGeneric.ml
@@ -156,11 +156,11 @@ let of_YUV420 img =
   let yuv_data =
     {
       yuv_pixel = Pixel.YUVJ420;
-      y = img.YUV420.y;
-      y_stride = img.YUV420.y_stride;
-      u = img.YUV420.u;
-      v = img.YUV420.v;
-      uv_stride = img.YUV420.uv_stride;
+      y = img.YUV420.planes.y;
+      y_stride = img.YUV420.planes.y_stride;
+      u = img.YUV420.planes.u;
+      v = img.YUV420.planes.v;
+      uv_stride = img.YUV420.planes.uv_stride;
     }
   in
   { data = YUV yuv_data; width = img.YUV420.width; height = img.YUV420.height }

--- a/src/imageYUV420.ml
+++ b/src/imageYUV420.ml
@@ -97,7 +97,9 @@ let make width height ?packed_data ?alpha y y_stride u v uv_stride =
   }
 
 let data_length ~alpha ~height ~y_stride ~uv_stride () =
-  height * (y_stride + uv_stride + if alpha then y_stride else 0)
+  (height * y_stride)
+  + (2 * (uv_height height * uv_stride))
+  + if alpha then height * y_stride else 0
 
 let make_data ?(alpha = false) width height data y_stride uv_stride =
   assert (data_length ~alpha ~height ~y_stride ~uv_stride () <= Data.length data);

--- a/src/image_yuv420.h
+++ b/src/image_yuv420.h
@@ -1,12 +1,16 @@
-#define YUV420_y(v) (Caml_ba_data_val(Field(v, 0)))
-#define YUV420_y_stride(v) (Int_val(Field(v, 1)))
-#define YUV420_u(v) (Caml_ba_data_val(Field(v, 2)))
-#define YUV420_v(v) (Caml_ba_data_val(Field(v, 3)))
-#define YUV420_uv_stride(v) (Int_val(Field(v, 4)))
-#define YUV420_width(v) (Int_val(Field(v, 5)))
-#define YUV420_height(v) (Int_val(Field(v, 6)))
+#define Planes(v) Field(v, 0)
+#define Plane(v, i) Field(Planes(v), i)
+#define Plane_data(v, i) Caml_ba_data_val(Plane(v, i))
+#define YUV420_y(v) Plane_data(v, 0)
+#define YUV420_y_stride(v) Int_val(Plane(v, 1))
+#define YUV420_u(v) Plane_data(v, 2)
+#define YUV420_v(v) Plane_data(v, 3)
+#define YUV420_uv_stride(v) Int_val(Plane(v, 4))
 #define YUV420_alpha(v)                                                        \
-  (Is_block(Field(v, 7)) ? Caml_ba_data_val(Field(Field(v, 7), 0)) : NULL)
+  (Is_block(Plane(v, 5)) ? Caml_ba_data_val(Field(Plane(v, 5), 0)) : NULL)
+
+#define YUV420_width(v) Int_val(Field(v, 1))
+#define YUV420_height(v) Int_val(Field(v, 2))
 
 typedef struct {
   int width;
@@ -33,6 +37,6 @@ static void yuv420_of_value(yuv420 *yuv, value v) {
 #define Y(yuv, i, j) yuv.y[j * yuv.y_stride + i]
 #define U2(yuv, i, j) yuv.u[j * yuv.uv_stride + i]
 #define V2(yuv, i, j) yuv.v[j * yuv.uv_stride + i]
-#define U(yuv, i, j) U2(yuv, i / 2, j / 2) 
-#define V(yuv, i, j) V2(yuv, i / 2, j / 2) 
+#define U(yuv, i, j) U2(yuv, i / 2, j / 2)
+#define V(yuv, i, j) V2(yuv, i / 2, j / 2)
 #define A(yuv, i, j) yuv.alpha[j * yuv.y_stride + i]


### PR DESCRIPTION
This PR changes the YUV frame layout to be stored into a single contiguous memory region when possible.

This makes it possible to pass frames as a single memory array pointer when possible.

When alpha channel is changed, the packed memory pointer is dropped.