### PR TITLE
scheduler: run duppy on a pool of domains and retire its monad

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+        uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: 5.3
       - name: Pin locally

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             extra-packages: alsa ao mad pulseaudio theora
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+      - uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add -n .

--- a/src/image.mli
+++ b/src/image.mli
@@ -101,6 +101,14 @@ module Bitmap : sig
   val set_pixel : t -> int -> int -> bool -> unit
   val scale : t -> t -> unit
 
+  (** What [Font.Make] needs of a suspension. *)
+  module type Lazy_t = sig
+    type 'a t
+
+    val from_fun : (unit -> 'a) -> 'a t
+    val force : 'a t -> 'a
+  end
+
   (** Operations on bitmap fonts. *)
   module Font : sig
     (** A font. *)
@@ -115,6 +123,16 @@ module Bitmap : sig
     (** Render text with given font, at given size (height of characters in
         pixels). *)
     val render : ?font:t -> ?size:int -> string -> bitmap
+
+    (** The character map is built on first use, so a program sharing a font
+        across domains instantiates this with a suspension of its own. *)
+    module Make (Lazy : Lazy_t) : sig
+      type t
+
+      val native : t
+      val height : t -> int
+      val render : ?font:t -> ?size:int -> string -> bitmap
+    end
   end
 end
 

--- a/src/imageBitmap.ml
+++ b/src/imageBitmap.ml
@@ -75,8 +75,16 @@ let blit src ?(x = 0) ?(y = 0) dst =
     done
   done
 
-(** Bitmap fonts. *)
-module Font = struct
+(** What [Font.Make] needs of a suspension: enough to defer building the
+    character map. *)
+module type Lazy_t = sig
+  type 'a t
+
+  val from_fun : (unit -> 'a) -> 'a t
+  val force : 'a t -> 'a
+end
+
+module Font_make (Lazy : Lazy_t) = struct
   module CharMap = Map.Make (struct
     type t = char
 
@@ -215,4 +223,10 @@ module Font = struct
         xoff := !xoff + font.width + font.char_space)
     done;
     rescale height font.height img
+end
+
+(** Bitmap fonts. *)
+module Font = struct
+  module Make = Font_make
+  include Font_make (Stdlib.Lazy)
 end


### PR DESCRIPTION
Mirror of savonet/liquidsoap#5359

Duppy queues were systhreads, and on OCaml 5 those all share domain 0's runtime lock, so they gave concurrency and no parallelism — adding queues subtracted throughput.

Duppy now spawns one dispatch domain per core plus one for the event loop, batching non-blocking tasks onto a domain and handing blocking ones an auxiliary thread inside it, so parking in a syscall frees the domain.

With domains in place the CPS monad OCaml 4 required is no longer needed: computations park on an effect and resume where they left off, so harbor, the telnet server and harbor output read and write their sockets as ordinary sequential code.

**Breaking:** `settings.scheduler.generic_queues`, `fast_queues` and `non_blocking_queues` are removed — they counted threads that no longer exist — and `settings.scheduler.blocking_tasks` replaces them to bound blocking tasks; scripts setting the old ones must drop those lines.

## Measurements

8 cores, OCaml 5.5.0.

| | before | after |
|---|---|---|
| 32 CPU-bound tasks, 1 → 6 domains | — | 3.04s → 0.449s (**6.8x**) |
| 16 CPU-bound tasks, 1 → 8 queues | 3.58s → 5.11s | — |
| 20ms periodic thread, 2 busy tasks | p50 **53.9ms** | p50 **0.09ms** |
| 20ms periodic thread, 4 busy tasks | p50 **100ms** | p50 **0.07ms** |
| 20ms periodic thread, 7 busy tasks | p50 **177ms** | p50 **0.06ms** |

The periodic thread has a clock thread's shape: the old medians are one 50ms systhread tick per contender, which is scheduler work delaying the streaming loop.

Effects are not a speed-up — a fiber per computation costs slightly more than the monad's closures. The one real gain is that a `Split` marker is compiled once per read rather than once per chunk.

## Degraded cases

**A flood of non-blocking tasks on one domain used to starve everything else.** Taking every ready immediate task on every round left blocking work unreachable whenever the ready list refilled as fast as it drained: 200 self-rearming tasks on one domain ran 2.6 million times in two seconds while a waiting blocking task never ran once. At four domains it was invisible, because the worker taking the batch hands the leftover blocking work to another worker and with one worker there is no other worker. A worker that just took a batch now takes a blocking task next when it has one and is under its cap, which bounds the wait to one batch per worker.

Batch length is still unbounded by design, so a task classified `Immediate` that does not return immediately is a latency bug the scheduler will not rescue.

**Clocks are unaffected by scheduler load, including on one core.** They stay on domain 0 rather than joining the pool, so they never queue for a dispatch slot and compete only for CPU — arbitrated by the OS across domains instead of by OCaml's 50ms tick within one. Pinned to a single core:

| busy tasks | p50 | p99 | max |
|---|---|---|---|
| 0 | 0.08 ms | 3.04 ms | 4.25 ms |
| 2 | 0.06 ms | 1.03 ms | 2.55 ms |
| 4 | 0.03 ms | 1.06 ms | 6.05 ms |
| 7 | 0.06 ms | 0.69 ms | 1.38 ms |

## Deletions

`duppy.ml` 1141 → 671 lines, `duppy.mli` 512 → 255, and `duppy_stubs.c` gone entirely: its only function backed `ba_write`, which the sole harbor transport implemented as `failwith "Not implemented!"` and nothing called. Duppy no longer has a C dependency. `Duppy.Monad.Mutex` and `Condition` went with `Server.condition`, which was exported but had no callers anywhere.

## Not here

Clocks keep their own threads and their own high-precision wait — they park inside `Pcm.writei` and a JACK semaphore, where no continuation can be captured, and the event loop's timer is `ceil(seconds * 1000)` against `clock_nanosleep` today. The O(pending-tasks) event loop is also untouched: 169 µs per iteration at 2000 idle clients is the remaining harbor ceiling.

## Tests

`src/modules/duppy/test/test_duppy.ml` covers cross-domain dispatch, batching, socket events, the blocking cap, draining on stop, effect resumption landing on a different domain than it started on, and the starvation case above. `tests/regression/scheduler_parallel.liq` checks that script handlers overlap. Each was falsified — reverted the fix, watched it go red — and the suite runs clean pinned to one core and under full CPU load. Harbor 5/5 and language process/socket/thread 3/3 pass; the telnet server, which has no automated test, was driven by hand.

Also fixes the logging thread returning without a final flush, which dropped everything logged during shutdown.
