### PR TITLE
Atomic sections for script state

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+        uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: 5.3
       - name: Pin locally

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             extra-packages: alsa ao mad pulseaudio theora
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+      - uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add -n .

--- a/src/image.mli
+++ b/src/image.mli
@@ -101,6 +101,14 @@ module Bitmap : sig
   val set_pixel : t -> int -> int -> bool -> unit
   val scale : t -> t -> unit
 
+  (** What [Font.Make] needs of a suspension. *)
+  module type Lazy_t = sig
+    type 'a t
+
+    val from_fun : (unit -> 'a) -> 'a t
+    val force : 'a t -> 'a
+  end
+
   (** Operations on bitmap fonts. *)
   module Font : sig
     (** A font. *)
@@ -115,6 +123,16 @@ module Bitmap : sig
     (** Render text with given font, at given size (height of characters in
         pixels). *)
     val render : ?font:t -> ?size:int -> string -> bitmap
+
+    (** The character map is built on first use, so a program sharing a font
+        across domains instantiates this with a suspension of its own. *)
+    module Make (Lazy : Lazy_t) : sig
+      type t
+
+      val native : t
+      val height : t -> int
+      val render : ?font:t -> ?size:int -> string -> bitmap
+    end
   end
 end
 

--- a/src/imageBitmap.ml
+++ b/src/imageBitmap.ml
@@ -75,8 +75,16 @@ let blit src ?(x = 0) ?(y = 0) dst =
     done
   done
 
-(** Bitmap fonts. *)
-module Font = struct
+(** What [Font.Make] needs of a suspension: enough to defer building the
+    character map. *)
+module type Lazy_t = sig
+  type 'a t
+
+  val from_fun : (unit -> 'a) -> 'a t
+  val force : 'a t -> 'a
+end
+
+module Font_make (Lazy : Lazy_t) = struct
   module CharMap = Map.Make (struct
     type t = char
 
@@ -215,4 +223,10 @@ module Font = struct
         xoff := !xoff + font.width + font.char_space)
     done;
     rescale height font.height img
+end
+
+(** Bitmap fonts. *)
+module Font = struct
+  module Make = Font_make
+  include Font_make (Stdlib.Lazy)
 end


### PR DESCRIPTION
Mirror of savonet/liquidsoap#5364

Script code has always run on a single core, so nothing in the language ever needed to say that a group of changes must not be observed half-done. Moving duppy to concurrent domains changes that, and this is in anticipation of it: a `ref` is a single atomic cell, so one cell stays safe and any group of cells does not. Two threads writing the same pair of references can interleave, and check-then-act — read a flag, find it unset, set it — lets both do the work.

`atomic(f)` runs `f` with no other atomic section running alongside:

```liquidsoap
def swap() =
  use_preempted := false
  use_boundary := false
end
atomic(swap)
```

Only sections are held back, so both sides of a race have to opt in. A section is indivisible, not transactional: if `f` raises, what it already changed stands. Nesting is a no-op. The optional `~fast` argument says the section is short and makes waiting threads spin rather than sleep; it defaults to `false`.

`Mutex_utils` already had the two release modes this needs, so the only new code is a reentrant lock on top of it, keyed by the holder's thread id. It moves from `src/core/utils` to `src/lang/prelude` as a pure rename — `Lang.reference` builds a reference over a caller's get and set and will need the same lock, and the language cannot see core. `liquidsoap_core_utils` already opens the prelude, so every core caller keeps its unqualified `Mutex_utils` unchanged. The builtin itself sits in `builtins_eval.ml`, next to the other one that runs script code.

A lost wake-up in `Mutex_utils` is fixed first, since scripts can now reach that lock: both wait loops read the lock state, saw a sleeping holder, and only then took the mutex to wait, so a holder releasing in that gap left the waiter asleep with nobody to broadcast.

`tests/language/atomic.liq` covers the return value, nesting, and that a raising section still releases. Its main case is an invariant — two threads keep a pair of references equal inside sections while a third checks them — run as a negative control with the `atomic` calls stripped: red 5/5, green 8/8 with them. The lost wake-up was reproduced on a copy of the wait loop with the window widened by a delay. Each of the four commits was built at its own SHA.
