### PR TITLE
Force the remaining lazy suspensions under a mutex

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+        uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: 5.3
       - name: Pin locally

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             extra-packages: alsa ao mad pulseaudio theora
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+      - uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add -n .

--- a/src/image.mli
+++ b/src/image.mli
@@ -101,6 +101,14 @@ module Bitmap : sig
   val set_pixel : t -> int -> int -> bool -> unit
   val scale : t -> t -> unit
 
+  (** What [Font.Make] needs of a suspension. *)
+  module type Lazy_t = sig
+    type 'a t
+
+    val from_fun : (unit -> 'a) -> 'a t
+    val force : 'a t -> 'a
+  end
+
   (** Operations on bitmap fonts. *)
   module Font : sig
     (** A font. *)
@@ -115,6 +123,16 @@ module Bitmap : sig
     (** Render text with given font, at given size (height of characters in
         pixels). *)
     val render : ?font:t -> ?size:int -> string -> bitmap
+
+    (** The character map is built on first use, so a program sharing a font
+        across domains instantiates this with a suspension of its own. *)
+    module Make (Lazy : Lazy_t) : sig
+      type t
+
+      val native : t
+      val height : t -> int
+      val render : ?font:t -> ?size:int -> string -> bitmap
+    end
   end
 end
 

--- a/src/imageBitmap.ml
+++ b/src/imageBitmap.ml
@@ -75,8 +75,16 @@ let blit src ?(x = 0) ?(y = 0) dst =
     done
   done
 
-(** Bitmap fonts. *)
-module Font = struct
+(** What [Font.Make] needs of a suspension: enough to defer building the
+    character map. *)
+module type Lazy_t = sig
+  type 'a t
+
+  val from_fun : (unit -> 'a) -> 'a t
+  val force : 'a t -> 'a
+end
+
+module Font_make (Lazy : Lazy_t) = struct
   module CharMap = Map.Make (struct
     type t = char
 
@@ -215,4 +223,10 @@ module Font = struct
         xoff := !xoff + font.width + font.char_space)
     done;
     rescale height font.height img
+end
+
+(** Bitmap fonts. *)
+module Font = struct
+  module Make = Font_make
+  include Font_make (Stdlib.Lazy)
 end


### PR DESCRIPTION
Mirror of savonet/liquidsoap#5367

Stacked on #5366.

`Lazy` is documented as unsafe to force from several fibers, systhreads or domains, which liquidsoap already does and is about to do in parallel. Every remaining suspension goes through `Lazy.Mutexed`, so a concurrent forcer blocks rather than leaving the outcome unspecified. A pre-commit hook rejects stdlib `Lazy` from now on.

The two suspensions #5365 already handled keep their `Atomic` memoization: `Clock.self_sync_type` is re-entered by the finalizer path, so a lock would trade a crash for a hung clock thread.

`Image.Bitmap.Font` becomes a functor over what it needs of a suspension, so mm keeps using the stdlib's `Lazy`.
