### PR TITLE
Fix time.zone.set and the osc handler's roots

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+        uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: 5.3
       - name: Pin locally

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             extra-packages: alsa ao mad pulseaudio theora
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ocaml/setup-ocaml@605a7e998e76e035b82c14d618a6e1010732c4ce # v3
+      - uses: ocaml/setup-ocaml@f92e0606b7ae4873dd1238465ea4bf6f8e40d85c # v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add -n .


### PR DESCRIPTION
Mirror of savonet/liquidsoap#5368

Stacked on #5365. Two independent fixes that came out of the scheduler work but need none of it.

`time.zone.set` now takes effect: setting the time zone was silently ignored once anything had already read the local time, which in practice meant always.

The osc handler registered global roots on two of its own locals and removed them at the end, which an unhandled argument type and any exception out of the callback both skip, leaving a root into a frame that has gone. Local roots leave with the frame however it is left.
